### PR TITLE
Incluir documentación de las rutas mediante OpenAPI

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import express from 'express'
 import dotenv from 'dotenv'
 import bodyParser from 'body-parser'
 import initMongoDBConnection from './api/config/mongoose.js'
+import swagger from './swagger.js'
 import applicationRoutes from './api/routes/ApplicationRoutes.js'
 import tripRoutes from './api/routes/TripRoutes.js'
 import actorRoutes from './api/routes/ActorRoutes.js'
@@ -33,6 +34,7 @@ configRoutes(app)
 loaderRoutes(app)
 dataWarehouseRoutes(app)
 
+swagger(app)
 
 try {
   await initMongoDBConnection()

--- a/openapi/actors.yml
+++ b/openapi/actors.yml
@@ -1,0 +1,101 @@
+openapi: 3.0.0
+info:
+  title: actors
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/actors:
+    get:
+      tags:
+        - actors
+      summary: listActors
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - actors
+      summary: createActor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                name: Pepardo
+                surname: Rodríguez
+                email: pep_la_presion@gmail.com
+                password: 123456789abcde
+                phone: '+34674747478'
+                address: 13 Rue del percebe
+                role: explorer
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/actors/{id}:
+    get:
+      tags:
+        - actors
+      summary: readActor
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e2732f60ea8efc059fb802
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - actors
+      summary: updateActor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                name: Pepardo
+                surname: Rodríguez
+                email: la_presion@gmail.com
+                password: LOL123456789abcde
+                phone: '+34674747478'
+                address: 15 Rue del percebe
+                role: explorer
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e2732f60ea8efc059fb802
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - actors
+      summary: deleteActor
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e2732f60ea8efc059fb802
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/applications.yml
+++ b/openapi/applications.yml
@@ -1,0 +1,162 @@
+openapi: 3.0.0
+info:
+  title: applications
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/applications:
+    get:
+      tags:
+        - applications
+      summary: listApplications
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e930e2f4865b4879b5
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - applications
+      summary: createApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                explorer: 63ed27e94fe8c982b12e364a
+                trip: 63f38bf93ff6b85445a656af
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}:
+    get:
+      tags:
+        - applications
+      summary: readApplication
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63f38500a1322a7f86e360bf
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}/accept:
+    patch:
+      tags:
+        - applications
+      summary: acceptApplication
+      requestBody:
+        content: {}
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63f38500a1322a7f86e360bf
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}/cancel:
+    patch:
+      tags:
+        - applications
+      summary: cancelApplication
+      requestBody:
+        content: {}
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63ed27871a2c14ab5ea16301
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}/pay:
+    patch:
+      tags:
+        - applications
+      summary: payApplication
+      requestBody:
+        content: {}
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63f38500a1322a7f86e360bf
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}/reject:
+    patch:
+      tags:
+        - applications
+      summary: rejectApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                rejectionReason: The payment period has expired
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63f38500a1322a7f86e360bf
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/applications/{id}/comments:
+    patch:
+      tags:
+        - applications
+      summary: updateApplicationComments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                comments: nada que comentar
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63ed27871a2c14ab5ea16301
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/dataWarehouse.yml
+++ b/openapi/dataWarehouse.yml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  title: dataWarehouse
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/dashboard:
+    get:
+      tags:
+        - dataWarehouse
+      summary: readDataWarehouse
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/dashboard/latest:
+    get:
+      tags:
+        - dataWarehouse
+      summary: readLatestDataWarehouse
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/dashboard/rebuild-period:
+    patch:
+      tags:
+        - dataWarehouse
+      summary: updateRebuildPeriod
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                period: 30
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/dashboard/spent-money-by-explorer:
+    post:
+      tags:
+        - dataWarehouse
+      summary: spentMoneyByExplorer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                explorer: 63ed27e96bb6772e5dab87ad
+                period: M06
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/dashboard/explorers-by-spent-money:
+    post:
+      tags:
+        - dataWarehouse
+      summary: explorersBySpentMoney
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                period: M36
+                theta: gte
+                v: 1
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/finders.yml
+++ b/openapi/finders.yml
@@ -1,0 +1,95 @@
+openapi: 3.0.0
+info:
+  title: finders
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/finders:
+    get:
+      tags:
+        - finders
+      summary: listFinders
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - finders
+      summary: createFinder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                explorer: 63e262f4bf4a27df6302e042
+                keyword: test
+                minPrice: 23
+                maxPrice: 2300
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/finders/{id}:
+    get:
+      tags:
+        - finders
+      summary: readFinder
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e2747a54e1a31e24e86ed8
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - finders
+      summary: updateFinder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                explorer: 63e262f4bf4a27df6302e042
+                minPrice: 2
+                maxPrice: 2300
+                keyword: pepe-leches
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e2747a54e1a31e24e86ed8
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - finders
+      summary: deleteFinder
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e274e454e1a31e24e86ede
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/globalConfig.yml
+++ b/openapi/globalConfig.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: globalConfig
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/config:
+    get:
+      tags:
+        - globalConfig
+      summary: listConfig
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - globalConfig
+      summary: updateConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                defaultLanguage: en
+                cacheLifetime: 3600
+                numResults: 10
+                sponsorshipFlatRate: 0.15
+                dataWhRefresh: 30
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/sponsorships.yml
+++ b/openapi/sponsorships.yml
@@ -1,0 +1,140 @@
+openapi: 3.0.0
+info:
+  title: sponsorships
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/sponsorships/{id}:
+    get:
+      tags:
+        - sponsorships
+      summary: readSponsorship
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fdbe7e997e6f723bfce9b6
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - sponsorships
+      summary: updateSponsorship
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                banner: >-
+                  TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCAuLi4=
+                link: https://messi.com/#goat
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e9db335a31d53ee505
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fdbe7e997e6f723bfce9b6
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - sponsorships
+      summary: deleteSponsorship
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e9db335a31d53ee505
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fb9b9f8ac35cf72c1610a2
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/sponsorships:
+    get:
+      tags:
+        - sponsorships
+      summary: listSponsorships
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e9db335a31d53ee505
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - sponsorships
+      summary: createSponsorship
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                tripId: 63f38bf93ff6b85445a656af
+                banner: >-
+                  TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCAuLi4=
+                link: https://www.cristianoronaldo.com/#cr7
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e9db335a31d53ee505
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/sponsorships/{id}/pay:
+    patch:
+      tags:
+        - sponsorships
+      summary: paySponsorship
+      requestBody:
+        content: {}
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e9db335a31d53ee505
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fdbe7e997e6f723bfce9b6
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/openapi/trips.yml
+++ b/openapi/trips.yml
@@ -1,0 +1,281 @@
+openapi: 3.0.0
+info:
+  title: trips
+  version: 1.0.0
+servers:
+  - url: localhost://
+paths:
+  /v1/trips:
+    get:
+      tags:
+        - trips
+      summary: listTrips
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - trips
+      summary: createTrip
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                title: Title
+                description: description
+                requirements: reequirements
+                startDate: '2023-07-10 15:00:00.000'
+                endDate: '2023-07-15 15:00:00.000'
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/search:
+    get:
+      tags:
+        - trips
+      summary: search
+      parameters:
+        - name: keyword
+          in: query
+          schema:
+            type: string
+          example: test
+        - name: minPrice
+          in: query
+          schema:
+            type: integer
+          example: '100'
+        - name: maxPrice
+          in: query
+          schema:
+            type: integer
+          example: '200'
+        - name: minDate
+          in: query
+          schema:
+            type: string
+          example: '2022-12-01'
+        - name: maxDate
+          in: query
+          schema:
+            type: string
+          example: '2022-12-05'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/trips/{id}/applications:
+    get:
+      tags:
+        - trips
+      summary: listTripApplications
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e144632ba413df4fa0d9b2
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - trips
+      summary: createTripApplications
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                comments: Por favor :(
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e942d65743deb07310
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e144632ba413df4fa0d9b2
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/trips/{id}:
+    get:
+      tags:
+        - trips
+      summary: readTrip
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63e144632ba413df4fa0d9b2
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - trips
+      summary: updateTrip
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                _id: 63fdd7ab2b7c7cf9b53122ee
+                title: Title (updated)
+                description: description
+                price: 0
+                requirements: reequirementsitos
+                startDate: '2023-07-10T13:00:00.000Z'
+                endDate: '2023-07-15T13:00:00.000Z'
+                publicationDate: null
+                cancellationDate: null
+                cancellationReason: null
+                pictures: []
+                stages:
+                  - title: Stage1
+                    description: Desc1lololololo
+                    price: 12
+                  - title: Stage2
+                    description: Desc2lololololo
+                    price: 18
+                sponsorships: []
+                creator: 63ed27e96f6eb8680cc0b162
+                createdAt: '2023-02-28T10:30:03.284Z'
+                updatedAt: '2023-02-28T10:30:03.284Z'
+                ticker: 230228-SVUR
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fdd7ab2b7c7cf9b53122ee
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - trips
+      summary: deleteTrip
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fdd7ab2b7c7cf9b53122ee
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/trips/{id}/publish:
+    patch:
+      tags:
+        - trips
+      summary: publishTrip
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                publicationDate: '2023-06-10T13:00:00.000Z'
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fddae384ad4f298551eff4
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /v1/trips/{id}/cancel:
+    patch:
+      tags:
+        - trips
+      summary: cancelTrip
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                cancellationReason: Porque quiero tio, porque me da la gana
+      parameters:
+        - name: actor_id
+          in: header
+          schema:
+            type: string
+          example: 63ed27e96f6eb8680cc0b162
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          example: 63fddae384ad4f298551eff4
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,53 @@
         "express": "^4.18.2",
         "express-validator": "^6.14.3",
         "mongoose": "^6.8.4",
-        "nanoid": "^4.0.0"
+        "nanoid": "^4.0.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^4.6.2"
       },
       "devDependencies": {
         "nodemon": "^2.0.20",
         "postman-to-openapi": "^3.0.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1104,6 +1146,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -1157,8 +1209,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1168,8 +1219,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1237,7 +1287,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1309,6 +1358,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1348,8 +1402,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1424,6 +1477,17 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -1449,6 +1513,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1572,6 +1644,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1602,6 +1679,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -1698,6 +1794,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1762,7 +1867,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1794,6 +1898,21 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/luxon": {
       "version": "3.2.1",
@@ -1876,7 +1995,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2095,12 +2213,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2402,6 +2542,63 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.16.1.tgz",
+      "integrity": "sha512-4J4XekQG0ol4/TyUzMfksrWsMTbw/7JYlT+SFaX7H0xamd1OeuVlUSb/Cbq4qdDx1lc+uLZQW7u2mlImcE8c+w=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.2.tgz",
+      "integrity": "sha512-MHIOaq9JrTTB3ygUJD+08PbjM5Tt/q7x80yz9VTFIatw8j5uIWKcr90S0h5NLMzFEDC6+eVprtoeA5MDZXCUKQ==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2529,9 +2726,84 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     }
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -3450,6 +3722,16 @@
         "tslib": "^2.3.1"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -3497,8 +3779,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -3508,8 +3789,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -3556,7 +3836,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3602,6 +3881,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -3627,8 +3911,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -3684,6 +3967,14 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -3703,6 +3994,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -3798,6 +4094,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3818,6 +4119,19 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -3879,6 +4193,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3928,7 +4251,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -3954,6 +4276,21 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "luxon": {
       "version": "3.2.1",
@@ -4009,7 +4346,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4168,10 +4504,29 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "openapi-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
+      "peer": true
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -4394,6 +4749,47 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "requires": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+        }
+      }
+    },
+    "swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "requires": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.16.1.tgz",
+      "integrity": "sha512-4J4XekQG0ol4/TyUzMfksrWsMTbw/7JYlT+SFaX7H0xamd1OeuVlUSb/Cbq4qdDx1lc+uLZQW7u2mlImcE8c+w=="
+    },
+    "swagger-ui-express": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.2.tgz",
+      "integrity": "sha512-MHIOaq9JrTTB3ygUJD+08PbjM5Tt/q7x80yz9VTFIatw8j5uIWKcr90S0h5NLMzFEDC6+eVprtoeA5MDZXCUKQ==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4484,6 +4880,35 @@
       "requires": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
+    },
+    "z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "requires": {
+        "commander": "^9.4.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "nanoid": "^4.0.0"
       },
       "devDependencies": {
-        "nodemon": "^2.0.20"
+        "nodemon": "^2.0.20",
+        "postman-to-openapi": "^3.0.1"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1153,6 +1154,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1327,6 +1334,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/concat-map": {
@@ -1742,6 +1758,24 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -1755,12 +1789,30 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/luxon": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
       "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/media-typer": {
@@ -1929,6 +1981,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
@@ -2057,6 +2118,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postman-to-openapi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
+      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^8.3.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.5",
+        "mustache": "^4.2.0"
+      },
+      "bin": {
+        "p2o": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14 <20"
       }
     },
     "node_modules/proxy-addr": {
@@ -3413,6 +3494,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -3530,6 +3617,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3831,6 +3924,21 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -3841,10 +3949,22 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "luxon": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
       "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+    },
+    "marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3969,6 +4089,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true
+    },
     "nanoid": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
@@ -4057,6 +4183,20 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "postman-to-openapi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
+      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
+      "dev": true,
+      "requires": {
+        "commander": "^8.3.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.5",
+        "mustache": "^4.2.0"
+      }
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node app.js",
     "dev": "nodemon app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "p2o": "node postmanToOpenapi.js"
   },
   "author": "",
   "license": "ISC",
@@ -22,6 +23,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "nodemon": "^2.0.20"
+    "nodemon": "^2.0.20",
+    "postman-to-openapi": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "express": "^4.18.2",
     "express-validator": "^6.14.3",
     "mongoose": "^6.8.4",
-    "nanoid": "^4.0.0"
+    "nanoid": "^4.0.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.2"
   },
   "type": "module",
   "devDependencies": {

--- a/postman/actors.postman_collection.json
+++ b/postman/actors.postman_collection.json
@@ -12,13 +12,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/actors",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"actors"
 					]
 				}
 			},
@@ -30,13 +30,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/actors/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"actors",
 						":id"
 					],
 					"variable": [
@@ -64,13 +64,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/actors/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"actors",
 						":id"
 					],
 					"variable": [
@@ -89,13 +89,13 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/actors/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"actors",
 						":id"
 					],
 					"variable": [
@@ -123,13 +123,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/actors",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"actors"
 					]
 				}
 			},

--- a/postman/applications.postman_collection.json
+++ b/postman/applications.postman_collection.json
@@ -18,13 +18,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/applications",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"applications"
 					]
 				}
 			},
@@ -36,13 +36,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/applications/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id"
 					],
 					"variable": [
@@ -70,13 +70,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/applications",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"applications"
 					]
 				}
 			},
@@ -88,13 +88,13 @@
 				"method": "PATCH",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/accept",
+					"raw": "localhost:8080/v1/applications/:id/accept",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id",
 						"accept"
 					],
@@ -114,13 +114,13 @@
 				"method": "PATCH",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/cancel",
+					"raw": "localhost:8080/v1/applications/:id/cancel",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id",
 						"cancel"
 					],
@@ -140,13 +140,13 @@
 				"method": "PATCH",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/pay",
+					"raw": "localhost:8080/v1/applications/:id/pay",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id",
 						"pay"
 					],
@@ -175,13 +175,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/reject",
+					"raw": "localhost:8080/v1/applications/:id/reject",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id",
 						"reject"
 					],
@@ -210,13 +210,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/comments",
+					"raw": "localhost:8080/v1/applications/:id/comments",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"applications",
 						":id",
 						"comments"
 					],

--- a/postman/dataWarehouse.postman_collection.json
+++ b/postman/dataWarehouse.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d04fcdc5-54e8-470b-ba1d-347d781490e7",
+		"_postman_id": "82da55aa-180c-4db4-a29f-740d3b4c845c",
 		"name": "dataWarehouse",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "25718361"
+		"_exporter_id": "24780295"
 	},
 	"item": [
 		{
@@ -12,13 +12,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/dashboard",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"dashboard"
 					]
 				}
 			},
@@ -30,13 +31,15 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{pathLatest}}",
+					"raw": "localhost:8080/v1/dashboard/latest",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{pathLatest}}"
+						"v1",
+						"dashboard",
+						"latest"
 					]
 				}
 			},
@@ -57,13 +60,14 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/rebuild-period",
+					"raw": "localhost:8080/v1/dashboard/rebuild-period",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"dashboard",
 						"rebuild-period"
 					]
 				}
@@ -71,7 +75,7 @@
 			"response": []
 		},
 		{
-			"name": "createCube1",
+			"name": "spentMoneyByExplorer",
 			"request": {
 				"method": "POST",
 				"header": [],
@@ -85,20 +89,22 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{cubePath1}}",
+					"raw": "localhost:8080/v1/dashboard/spent-money-by-explorer",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{cubePath1}}"
+						"v1",
+						"dashboard",
+						"spent-money-by-explorer"
 					]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "createCube2",
+			"name": "explorersBySpentMoney",
 			"request": {
 				"method": "POST",
 				"header": [],
@@ -112,13 +118,15 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{cubePath2}}",
+					"raw": "localhost:8080/v1/dashboard/explorers-by-spent-money",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{cubePath2}}"
+						"v1",
+						"dashboard",
+						"explorers-by-spent-money"
 					]
 				}
 			},

--- a/postman/finders.postman_collection.json
+++ b/postman/finders.postman_collection.json
@@ -12,13 +12,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/finders",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"finders"
 					]
 				}
 			},
@@ -30,13 +30,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/finders/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"finders",
 						":id"
 					],
 					"variable": [
@@ -64,13 +64,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/finders/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"finders",
 						":id"
 					],
 					"variable": [
@@ -89,13 +89,13 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/finders/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"finders",
 						":id"
 					],
 					"variable": [
@@ -123,13 +123,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/finders",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"finders"
 					]
 				}
 			},

--- a/postman/globalConfig.postman_collection.json
+++ b/postman/globalConfig.postman_collection.json
@@ -12,13 +12,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/config",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"config"
 					]
 				}
 			},
@@ -39,13 +39,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/config",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"config"
 					]
 				}
 			},

--- a/postman/sponsorships.postman_collection.json
+++ b/postman/sponsorships.postman_collection.json
@@ -12,13 +12,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/sponsorships/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"sponsorships",
 						":id"
 					],
 					"variable": [
@@ -43,13 +43,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/sponsorships",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"sponsorships"
 					]
 				}
 			},
@@ -67,13 +67,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/pay",
+					"raw": "localhost:8080/v1/sponsorships/:id/pay",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"sponsorships",
 						":id",
 						"pay"
 					],
@@ -108,13 +108,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/sponsorships/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"sponsorships",
 						":id"
 					],
 					"variable": [
@@ -139,13 +139,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/sponsorships/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"sponsorships",
 						":id"
 					],
 					"variable": [
@@ -179,13 +179,13 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/sponsorships",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost:8080"
 					],
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"sponsorships"
 					]
 				}
 			},

--- a/postman/trips.postman_collection.json
+++ b/postman/trips.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9c8f6454-bb78-4e7a-b532-a70ce9212461",
+		"_postman_id": "83074802-359b-4628-ac3f-4a7c256c04d0",
 		"name": "trips",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "24780295"
@@ -18,13 +18,14 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/trips",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"trips"
 					]
 				}
 			},
@@ -36,19 +37,19 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/search?minPrice=100&maxPrice=200",
+					"raw": "localhost:8080/v1/search?keyword=test&minPrice=100&maxPrice=200&minDate=2022-12-01&maxDate=2022-12-05",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
+						"v1",
 						"search"
 					],
 					"query": [
 						{
 							"key": "keyword",
-							"value": "test",
-							"disabled": true
+							"value": "test"
 						},
 						{
 							"key": "minPrice",
@@ -60,13 +61,11 @@
 						},
 						{
 							"key": "minDate",
-							"value": "2022-12-01",
-							"disabled": true
+							"value": "2022-12-01"
 						},
 						{
 							"key": "maxDate",
-							"value": "2022-12-05",
-							"disabled": true
+							"value": "2022-12-05"
 						}
 					]
 				}
@@ -85,13 +84,14 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/applications",
+					"raw": "localhost:8080/v1/trips/:id/applications",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id",
 						"applications"
 					],
@@ -126,97 +126,16 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/applications",
+					"raw": "localhost:8080/v1/trips/:id/applications",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id",
 						"applications"
-					],
-					"variable": [
-						{
-							"key": "id",
-							"value": "63e144632ba413df4fa0d9b2"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addTripSponsorship",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "actor_id",
-						"value": "63e143773c3c619deba0bd8b",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"sponsor\": \"63e144632ba413df4fa0d9b6\",\n    \"banner\": \"TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCAuLi4=\",\n    \"link\": \"https://www.cristianoronaldo.com/#cr7\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/sponsorships",
-					"host": [
-						"{{host}}{{port}}"
-					],
-					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
-						":id",
-						"sponsorships"
-					],
-					"variable": [
-						{
-							"key": "id",
-							"value": "63e144632ba413df4fa0d9b2"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateTripSponsorship",
-			"request": {
-				"method": "PATCH",
-				"header": [
-					{
-						"key": "actor_id",
-						"value": "63e143773c3c619deba0bd8b",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"sponsorships\": [\n        {\n            \"sponsor\": \"63e144632ba413df4fa0d9b6\",\n            \"banner\": \"TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCAuLi4=\",\n            \"link\": \"https://www.cristianoronaldo.com/#cr7\"\n        }\n    ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/sponsorships",
-					"host": [
-						"{{host}}{{port}}"
-					],
-					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
-						":id",
-						"sponsorships"
 					],
 					"variable": [
 						{
@@ -234,13 +153,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/trips/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id"
 					],
 					"variable": [
@@ -274,13 +194,14 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/publish",
+					"raw": "localhost:8080/v1/trips/:id/publish",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id",
 						"publish"
 					],
@@ -315,13 +236,14 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id/cancel",
+					"raw": "localhost:8080/v1/trips/:id/cancel",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id",
 						"cancel"
 					],
@@ -356,13 +278,14 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/trips/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id"
 					],
 					"variable": [
@@ -387,13 +310,14 @@
 					}
 				],
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}/:id",
+					"raw": "localhost:8080/v1/trips/:id",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}",
+						"v1",
+						"trips",
 						":id"
 					],
 					"variable": [
@@ -427,13 +351,14 @@
 					}
 				},
 				"url": {
-					"raw": "{{host}}{{port}}/{{apiVersion}}/{{path}}",
+					"raw": "localhost:8080/v1/trips",
 					"host": [
-						"{{host}}{{port}}"
+						"localhost"
 					],
+					"port": "8080",
 					"path": [
-						"{{apiVersion}}",
-						"{{path}}"
+						"v1",
+						"trips"
 					]
 				}
 			},

--- a/postmanToOpenapi.js
+++ b/postmanToOpenapi.js
@@ -1,0 +1,54 @@
+import postmanToOpenApi from 'postman-to-openapi'
+import { join } from 'node:path'
+import { readdirSync, existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+
+const API_VERSION = 'v1'
+
+const postmanDir = './postman'
+const openapiDir = './openapi'
+
+// read all postman collections and store its names
+const getPostmanFiles = (dir) => {
+    return 
+}
+
+// convert the postman collection file into an openapi specification
+const convertToOpenApi = async (filename) => {
+    const collectionName = filename.split('.')[0]
+    const postmanFilename = join(postmanDir, filename)
+    const openApiFilename = join(openapiDir, `${collectionName}.yml`)
+
+    console.log('Creating OpenAPI specification for collection', collectionName)
+    try {
+        const result = await postmanToOpenApi(postmanFilename, null, { defaultTag: collectionName })
+        if (result) {
+            console.log(`OpenAPI spec for collection ${collectionName} created`)
+            await writeFile(openApiFilename, result)
+            console.log(`OpenAPI file ${collectionName}.yml generated`)
+        } else {
+            throw new Error()
+        }
+    } catch (err) {
+        console.log('An error occurred while creating the OpenAPI file for collection', collectionName)
+        console.log(err)
+    }
+}
+
+if (!existsSync(openapiDir)) {
+    console.log('OpenAPI  directory does not exist, create it in the root folder')
+    process.exit()
+}
+
+const filenames = readdirSync(postmanDir)
+const openApiCollections = filenames.map(filename => convertToOpenApi(filename))
+
+try {
+    const result = await Promise.all(openApiCollections)
+    console.log('-----------------------------')
+    console.log('OpenAPI files generated succesfully!')
+} catch (err) {
+    console.log('xxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    console.log('Something went wrong', err)
+}
+

--- a/postmanToOpenapi.js
+++ b/postmanToOpenapi.js
@@ -24,7 +24,8 @@ const convertToOpenApi = async (filename) => {
         const result = await postmanToOpenApi(postmanFilename, null, { defaultTag: collectionName })
         if (result) {
             console.log(`OpenAPI spec for collection ${collectionName} created`)
-            await writeFile(openApiFilename, result)
+            const formatResult = result.replace(/\/080\//g, '/')
+            await writeFile(openApiFilename, formatResult)
             console.log(`OpenAPI file ${collectionName}.yml generated`)
         } else {
             throw new Error()

--- a/swagger.js
+++ b/swagger.js
@@ -1,0 +1,30 @@
+import swaggerJSDoc from 'swagger-jsdoc';
+import swaggerUI from 'swagger-ui-express'
+
+const options = {
+    definition: {
+        openapi: '3.0.0',
+        info: {
+        title: 'ACME-Explorer API',
+        version: '1.0.0',
+        description:
+            'Specification of models and endpoints for communication and integration with the ACME-Explorer API.'
+        },
+        servers: [{
+        url: `http://localhost:8080`,
+        description: 'Development server'
+        }],
+    },
+    apis: ['openapi/*.yml'],
+}
+
+const swaggerSpec = swaggerJSDoc(options);
+const swaggerDocs = (app) => {
+    app.use('/docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec))
+    app.get('/docs.json', (req, res) => {
+        res.setHeader('Content-Type', 'application/json')
+        res.send(swaggerSpec)
+    })
+}
+
+export default swaggerDocs


### PR DESCRIPTION
Con esta PR se incluye la documentación de todas las rutas de la API, que serán visibles en el endpoint `/docs` al desplegar el servicio.

Además, he incluido un mecanismo a través del cual se pueden generar archivos de especificación OpenAPI a partir de una colección de postman. Para hacerlo basta con utilizar el comando `npm run p2o` y los archivos dentro de la carpeta *openapi* del directorio raíz se actualizarán. Es importante mencionar que he tenido que modificar todos las colecciones de postman para que esto funcionase de una forma simple y rápida. Básicamente he eliminado todas las variables de postman sustituyéndolas por sus valores.

closes #13 